### PR TITLE
Fix double dash note in kickstart lvm guide

### DIFF
--- a/modules/install-guide/pages/Kickstart2.adoc
+++ b/modules/install-guide/pages/Kickstart2.adoc
@@ -1110,7 +1110,7 @@ Create a logical volume for Logical Volume Management (LVM). For more informatio
 [NOTE]
 ====
 
-Do not use the dash (`-`) character in logical volume and volume group names when installing {PRODUCT} using Kickstart. If this character is used, the installation finishes normally, but the `/dev/mapper/` directory will list these volumes and volume groups with every dash doubled. For example, a volume group named `volgrp-01` containing a logical volume named `logvol-01` will be listed as `/dev/mapper/volgrp--01-logvol--01`.
+Do not use the dash (`-`) character in logical volume and volume group names when installing {PRODUCT} using Kickstart. If this character is used, the installation finishes normally, but the `/dev/mapper/` directory will list these volumes and volume groups with every dash doubled. For example, a volume group named `volgrp-01` containing a logical volume named `logvol-01` will be listed as `/dev/mapper/volgrp\--01-logvol\--01`.
 
 This limitation only applies to newly created logical volume and volume group names. If you are reusing existing ones using the [option]`--noformat` option, their names will not be changed.
 
@@ -2371,7 +2371,7 @@ Creates a Logical Volume Management (LVM) group.
 [IMPORTANT]
 ====
 
-Do not use the dash (`-`) character in logical volume and volume group names when installing {PRODUCT} using Kickstart. If this character is used, the installation finishes normally, but the `/dev/mapper/` directory will list these volumes and volume groups with every dash doubled. For example, a volume group named `volgrp-01` containing a logical volume named `logvol-01` will be listed as `/dev/mapper/volgrp--01-logvol--01`.
+Do not use the dash (`-`) character in logical volume and volume group names when installing {PRODUCT} using Kickstart. If this character is used, the installation finishes normally, but the `/dev/mapper/` directory will list these volumes and volume groups with every dash doubled. For example, a volume group named `volgrp-01` containing a logical volume named `logvol-01` will be listed as `/dev/mapper/volgrp\--01-logvol\--01`.
 
 This limitation only applies to newly created logical volume and volume group names. If you are reusing existing ones using the [option]`--noformat` option, their names will not be changed.
 


### PR DESCRIPTION
This is currently rendered as `volgrp—​01-logvol—​01`