### PR TITLE
Correct path for vmlinuz and initrd.img

### DIFF
--- a/modules/install-guide/pages/pxe-server.adoc
+++ b/modules/install-guide/pages/pxe-server.adoc
@@ -203,12 +203,12 @@ The [option]`inst.repo=` [application]*Anaconda* option, shown in the example ab
 
 ====
 
-. Create a subdirectory to store the boot image files within the `/var/lib/tftpboot/` directory, and copy the boot image files to it. In this example, we use the directory `/var/lib/tftpboot/images/{PRODUCT}-{PRODVER}/`:
+. Create a subdirectory to store the boot image files within the `/var/lib/tftpboot/` directory, and copy the boot image files to it. In this example, we use the directory `/var/lib/tftpboot/pxelinux/images/{PRODUCT}-{PRODVER}/`:
 +
 [literal,subs="+quotes,attributes,verbatim,macros"]
 ....
 # [command]`mkdir -p /var/lib/tftpboot/images/{PRODUCT}-{PRODVER}/`
-# [command]`cp /path-to-x86-64-images/pxeboot/{vmlinuz,initrd.img} /var/lib/tftpboot/images/{PRODUCT}-{PRODVER}/`
+# [command]`cp /path-to-x86-64-images/pxeboot/{vmlinuz,initrd.img} /var/lib/tftpboot/pxelinux/images/{PRODUCT}-{PRODVER}/`
 ....
 
 . Finally, start and enable the services:


### PR DESCRIPTION
The path to store ```vmlinuz``` and ```initrd.img``` seems incorrect. The ```images``` sub-folder where they are copied should be under the folder ```pxelinux``` and not directly under ```/var/lib/tftpboot```. The information is correct on the CentOS 8 docs: https://docs.centos.org/en-US/8-docs/advanced-install/assembly_preparing-for-a-network-install/

```
Create a subdirectory to store the boot image files in the /var/lib/tftpboot/ directory, and copy the boot image files to the directory. In this example, we use the directory /var/lib/tftpboot/pxelinux/images/CentOS-8.0.1905/:

# mkdir -p /var/lib/tftpboot/pxelinux/images/CentOS-8.0.1905/
# cp /path_to_x86_64_images/pxeboot/{vmlinuz,initrd.img} /var/lib/tftpboot/pxelinux/images/CentOS-8.0.1905/
```