### PR TITLE
Update Simple_Installation.adoc

### DIFF
--- a/modules/install-guide/pages/Simple_Installation.adoc
+++ b/modules/install-guide/pages/Simple_Installation.adoc
@@ -208,7 +208,7 @@ Set the [option]`inst.stage2=hd:LABEL=` option and [option]`inst.ks=hd:LABEL=` o
 +
 [literal,subs="+quotes,attributes,verbatim"]
 ....
-`mount /root/centos-install/images/efiboot.img /mnt/`
+`mount /root/{PRODUCT}-install/images/efiboot.img /mnt/`
 ....
 +
 Edit the file `/mnt/EFI/BOOT/grub`:
@@ -232,7 +232,7 @@ Edit the file `/mnt/EFI/BOOT/grub`:
 +
 * For a **CDROM UEFI boot**, follow the steps:
 +
-.. Edit the file `/root/rhel-install/EFI/BOOT/grub.cfg`:
+.. Edit the file `/root/{PRODUCT}-install/EFI/BOOT/grub.cfg`:
 +
 .. Add a new menu entry to the file:
 +


### PR DESCRIPTION
Updated some hard coded paths to use {PRODUCT} instead.  This fixes a case mismatch between the working directory and one of the paths used.  It also replaces a /root/rhel-install path with a path matching the {PRODUCT}.