### PR TITLE
Update Simple_Installation.adoc

### DIFF
--- a/modules/install-guide/pages/Simple_Installation.adoc
+++ b/modules/install-guide/pages/Simple_Installation.adoc
@@ -211,7 +211,7 @@ Set the [option]`inst.stage2=hd:LABEL=` option and [option]`inst.ks=hd:LABEL=` o
 `mount /root/centos-install/images/efiboot.img /mnt/`
 ....
 +
-Edit the file `/mnt/EFI/BOOT/grub`:
+Edit the file `/mnt/EFI/BOOT/grub.cfg`:
 +
 .. Add a new menu entry:
 +


### PR DESCRIPTION
Fixed a bug in the path to the /mnt/EFI/BOOT/grub.cfg file.  The extension was missing.